### PR TITLE
include docs and tests in MANIFEST.in

### DIFF
--- a/MANIFEST.in
+++ b/MANIFEST.in
@@ -1,7 +1,3 @@
 recursive-include tests *
 recursive-include docs *
-recursive-include tests *.pyc
-recursive-include tests *.pyo
-recursive-include docs *.pyc
-recursive-include docs *.pyo
 prune docs/_build

--- a/MANIFEST.in
+++ b/MANIFEST.in
@@ -1,0 +1,7 @@
+recursive-include tests *
+recursive-include docs *
+recursive-include tests *.pyc
+recursive-include tests *.pyo
+recursive-include docs *.pyc
+recursive-include docs *.pyo
+prune docs/_build


### PR DESCRIPTION
The PyPI source tarballs don't have tests and docs included by now, which IMO isn't a good practice.